### PR TITLE
[feat]Geolocation APIを使ったユーザーの位置情報(緯度, 経度)を取得する機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel
@@ -34,3 +35,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+

--- a/app/api/user-location-info/route.ts
+++ b/app/api/user-location-info/route.ts
@@ -21,7 +21,8 @@ export async function GET(request: Request) {
 
         // エラーレスポンスの処理
         if (!response.ok) {
-            return NextResponse.json({ error: 'Failed to get user location' }, { status: response.status });
+            const errorData = await response.json();
+            return NextResponse.json({ error: 'Failed to get user location', details: errorData }, { status: response.status });
         }
         
         // レスポンスデータをJSON形式で返す

--- a/app/api/user-location-info/route.ts
+++ b/app/api/user-location-info/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const GOOGLE_MAPS_GEOCODING_API_KEY = process.env.GOOGLE_MAPS_GEOCODING_API_KEY; // .envファイルにAPIキーを保存
+
+// GETリクエストの処理
+export async function GET(request: Request) {
+    if (!GOOGLE_MAPS_GEOCODING_API_KEY) {
+        return NextResponse.json({ error: 'API key is not set' }, { status: 500 });
+    }
+    const apiUrl = 'https://www.googleapis.com/geolocation/v1/geolocate?key=' + GOOGLE_MAPS_GEOCODING_API_KEY;
+
+    try {
+        // ユーザーの位置情報を取得
+        const response = await fetch(apiUrl, {
+            method: 'POST',
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({})
+        });
+
+        // エラーレスポンスの処理
+        if (!response.ok) {
+            return NextResponse.json({ error: 'Failed to get user location' }, { status: response.status });
+        }
+        
+        // レスポンスデータをJSON形式で返す
+        const data = await response.json();
+        return NextResponse.json(data);
+    }
+    // エラーハンドリング
+    catch (error) {
+        return NextResponse.json({ error: 'Server error', details: error }, { status: 500 });
+    }
+}

--- a/app/api/user-location-info/route.ts
+++ b/app/api/user-location-info/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const GOOGLE_MAPS_GEOCODING_API_KEY = process.env.GOOGLE_MAPS_GEOCODING_API_KEY; // .envファイルにAPIキーを保存
+const GOOGLE_MAPS_GEOLOCATION_API_KEY = process.env.GOOGLE_MAPS_GEOLOCATION_API_KEY; // .envファイルにAPIキーを保存
 
 // GETリクエストの処理
 export async function GET(request: Request) {
-    if (!GOOGLE_MAPS_GEOCODING_API_KEY) {
+    if (!GOOGLE_MAPS_GEOLOCATION_API_KEY) {
         return NextResponse.json({ error: 'API key is not set' }, { status: 500 });
     }
-    const apiUrl = 'https://www.googleapis.com/geolocation/v1/geolocate?key=' + GOOGLE_MAPS_GEOCODING_API_KEY;
+    const apiUrl = 'https://www.googleapis.com/geolocation/v1/geolocate?key=' + GOOGLE_MAPS_GEOLOCATION_API_KEY;
 
     try {
         // ユーザーの位置情報を取得


### PR DESCRIPTION
## 概要
Geolocation APIを使って位置情報(緯度, 経度)を取得するroute.tsファイルの作成

## 確認方法
.env.locationファイルに以下を追加(`your_api_key`は自分のGeolocation API keyを入力)
```
GOOGLE_MAPS_GEOLOCATION_API_KEY=your_api_key
```

入力
```
curl -X GET http://localhost:3000/api/user-location-info
```
出力例
```
{"location":{"lat":37.4293536,"lng":138.7819785},"accuracy":21717.731411179695}
```
`lat`: 緯度
`lng`: 経度
`accuracy`: 誤差円半径