### PR TITLE
[feat]回答進捗を作成

### DIFF
--- a/components/AnswerProgressBar/AnswerProgressBar.tsx
+++ b/components/AnswerProgressBar/AnswerProgressBar.tsx
@@ -1,0 +1,20 @@
+'use client';
+import React from 'react';
+
+interface AnswerProgressBarPops {
+  value: number; // 進捗度 (0-100)
+}
+
+export default function AnswerProgressBar(props: AnswerProgressBarPops) {
+  // value が 0-100 の範囲外の場合の処理
+  const clampedValue = Math.max(0, Math.min(100, props.value));
+
+  return (
+    <div className={'w-full h-2.5 rounded-l-full rounded-r-xs border border-main-3 '}>
+      <div
+        className="bg-main-3 h-full rounded-l-full "
+        style={{ width: `${clampedValue}%` }}
+      ></div>
+    </div>
+  );
+}


### PR DESCRIPTION
回答進捗のプログレスバーを作成
引数で与えた数字（0~100）%ゲージが満たされる。
hook使ってないけどAIに聞いたら多分引数が変わったらReactくんが再描画してくれるって言ってた。

以下のようになる（画像用のもので、pageは書き換えてません）
![image](https://github.com/user-attachments/assets/85fccb04-b5fd-40bf-aef7-6c19c4daecf9)
