### PR TITLE
[feat]詳細設定の選択ボタンを作成

### DIFF
--- a/components/SettingsSelectionButton/SettingsSelectionButton.tsx
+++ b/components/SettingsSelectionButton/SettingsSelectionButton.tsx
@@ -1,0 +1,21 @@
+'use client';
+import React from "react";
+
+interface SettingsSelectionButtonProps {
+  label: string;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+// 詳細設定の選択ボタン
+export default function SettingsSelectionButton(props: SettingsSelectionButtonProps) {
+  const buttonClassName = 'px-3 py-2 rounded-full shadow-md shadow-sub'+ 
+    (props.isSelected ? ' bg-main-2' : ' bg-base');
+  const textClassName = 'text-label-1' +
+    (props.isSelected ? ' text-text-light' : ' text-text-dark');
+  return (
+      <button className={buttonClassName} onClick={props.onClick}>
+          <div className={textClassName}>{props.label}</div>
+      </button>
+  );
+}


### PR DESCRIPTION
詳細設定の選択ボタンを作成しました。

引数
- label：選択肢の名前（string）
- isSelected：選択中かどうか（boolean）
- onClick：タップ時の処理（void）

isSelectedがtureかfalseかで色が変わります。

以下の画像のようになる（画像のためで、pageは書き換えないです）
![image](https://github.com/user-attachments/assets/bedf7f25-5002-45c2-988b-52ccff143e0a)
